### PR TITLE
Mastodon のメンション正規表現に近づける

### DIFF
--- a/lnb-mastodon-client/src/text.rs
+++ b/lnb-mastodon-client/src/text.rs
@@ -11,8 +11,9 @@ use url::Url;
 static RE_HEAD_MENTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"^\s*(\[@.+?\]\(.+?\)\s*)+"#).expect("invalid regex"));
 
+// https://github.com/mastodon/mastodon/blob/7d2dda97b3610747867861c0c7155f3e2ad94a47/app/models/account.rb#L73-L74
 static RE_ESCAPING_MENTION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?:^|\s)@([A-Za-z0-9_]+)"#).expect("invalid regex"));
+    LazyLock::new(|| Regex::new(r#"(^|[^=/[:word:]])@([[:word:]]+)"#).expect("invalid regex"));
 
 pub fn sanitize_mention_html_from_mastodon(mention_html: &str) -> String {
     let content_markdown = parse_html(mention_html);
@@ -88,7 +89,7 @@ fn walk_mastodon(writer: &mut impl Write, children: Vec<Node>) -> FmtResult {
 }
 
 fn write_text_element(writer: &mut impl Write, original: &str) -> FmtResult {
-    let escaped = RE_ESCAPING_MENTION.replace_all(original, "(at)$1");
+    let escaped = RE_ESCAPING_MENTION.replace_all(original, "$1(at)$2");
     write!(writer, "{escaped}")?;
     Ok(())
 }


### PR DESCRIPTION
Closes #44 

https://mstdn.maud.io/@unarist/114861772390991170

regex crate には lookahead negative match がないのでそれっぽいので代用