### PR TITLE
math-renderer の出力画像が PNG のままになるように細工する

### DIFF
--- a/lnb-common/src/math_renderer.rs
+++ b/lnb-common/src/math_renderer.rs
@@ -40,6 +40,7 @@ impl MathRendererClient {
             "formula": formula,
             "display": display_mode,
             "scale": self.scale,
+            "preserveAlpha": true,
         });
         let resp = self
             .client
@@ -65,6 +66,7 @@ impl MathRendererClient {
         let payload = json!({
             "formulae": formulae,
             "scale": self.scale,
+            "preserveAlpha": true,
         });
         let resp = self
             .client

--- a/lnb-math-renderer/src/api/endpoints.ts
+++ b/lnb-math-renderer/src/api/endpoints.ts
@@ -30,6 +30,7 @@ export async function renderMath(
     try {
         const png = await renderToPng(request.formula.trim(), request.display, {
             scale: request.scale ?? 1.0,
+            preserveAlpha: request.preserveAlpha,
             padding: 20,
         });
         return new Response(png, {
@@ -57,6 +58,7 @@ export async function renderMathMultiple(
     try {
         const png = await renderMultipleToPng(request.formulae, {
             scale: request.scale ?? 1.0,
+            preserveAlpha: request.preserveAlpha,
             padding: 20,
         });
         return new Response(png, {

--- a/lnb-math-renderer/src/api/schema.ts
+++ b/lnb-math-renderer/src/api/schema.ts
@@ -9,41 +9,65 @@ export interface RenderMultipleRequestBody {
     scale: number;
 }
 
+export interface RenderCommonOption {
+    scale: number;
+    preserveAlpha: boolean;
+}
+
 export interface ErrorResponse {
     error: string;
 }
 
 export function validateRenderMultipleRequest(
-    request: unknown,
-): request is RenderMultipleRequestBody {
-    if (typeof request !== "object" || request === null) {
+    payload: unknown,
+): payload is RenderMultipleRequestBody & RenderCommonOption {
+    if (typeof payload !== "object" || payload === null) {
         return false;
     }
 
     if (
-        !("formulae" in request) ||
-        !Array.isArray(request.formulae) ||
-        request.formulae.length === 0 ||
-        !request.formulae.every((f) => typeof f === "string")
+        !("formulae" in payload) ||
+        !Array.isArray(payload.formulae) ||
+        payload.formulae.length === 0 ||
+        !payload.formulae.every((f) => typeof f === "string")
     ) {
         return false;
     }
 
-    return true;
+    return validateCommonOption(payload);
 }
 
 export function validateRenderRequest(
-    request: unknown,
-): request is RenderRequestBody {
-    if (typeof request !== "object" || request === null) {
+    payload: unknown,
+): payload is RenderRequestBody & RenderCommonOption {
+    if (typeof payload !== "object" || payload === null) {
         return false;
     }
 
-    if (!("formula" in request) || typeof request.formula !== "string") {
+    if (!("formula" in payload) || typeof payload.formula !== "string") {
         return false;
     }
 
-    if (!("display" in request) || typeof request.display !== "boolean") {
+    if (!("display" in payload) || typeof payload.display !== "boolean") {
+        return false;
+    }
+
+    return validateCommonOption(payload);
+}
+
+function validateCommonOption(payload: unknown): payload is RenderCommonOption {
+    if (typeof payload !== "object" || payload === null) {
+        return false;
+    }
+
+    if (!("scale" in payload) || typeof payload.scale !== "number") {
+        return false;
+    }
+
+    if (
+        !("preserveAlpha" in payload) ||
+        typeof payload.preserveAlpha !== "boolean"
+    ) {
         return false;
     }
 

--- a/lnb-math-renderer/src/rendering/latex.ts
+++ b/lnb-math-renderer/src/rendering/latex.ts
@@ -5,7 +5,7 @@ const RENDERING_EX_SIZE = 32;
 const RASTERIZE_DENSITY = 96;
 const FORMULA_GAP = 24;
 const LABEL_MARGIN = 16;
-const LABEL_WIDTH = 48;
+const LABEL_WIDTH = 128;
 
 interface MathJaxInstance {
     tex2svgPromise: (
@@ -144,7 +144,11 @@ export async function renderMultipleToPng(
         maxFormulaWidth = Math.max(maxFormulaWidth, formulaWidth);
         totalFormulaHeight += formulaHeight;
 
-        compositeInputs.push({ input: formulaImage, top: y, left: 0 });
+        compositeInputs.push({
+            input: formulaImage,
+            top: y,
+            left: LABEL_MARGIN + LABEL_WIDTH,
+        });
 
         // Label
         const labelPng = await sharp({
@@ -165,7 +169,7 @@ export async function renderMultipleToPng(
         compositeInputs.push({
             input: labelPng,
             top: labelTop,
-            left: formulaWidth + LABEL_MARGIN,
+            left: LABEL_MARGIN,
         });
 
         // Linefeed

--- a/lnb-math-renderer/src/rendering/latex.ts
+++ b/lnb-math-renderer/src/rendering/latex.ts
@@ -49,6 +49,7 @@ export interface RenderOptions {
     readonly scale?: number;
     readonly padding?: number;
     readonly backgroundColor?: string;
+    readonly preserveAlpha?: boolean;
 }
 
 async function renderSvgToPng(
@@ -70,6 +71,38 @@ async function renderSvgToPng(
         .flatten({ background })
         .png()
         .toBuffer();
+}
+
+async function addPaddings(
+    original: Buffer,
+    padding: number,
+    background: string,
+    reserveAlpha: boolean,
+): Promise<Buffer> {
+    let imageBuffer = original;
+    if (padding > 0) {
+        imageBuffer = await sharp(imageBuffer)
+            .extend({
+                top: padding,
+                bottom: padding,
+                left: padding,
+                right: padding,
+                background,
+            })
+            .toBuffer();
+    }
+    if (reserveAlpha) {
+        imageBuffer = await sharp(imageBuffer)
+            .extend({
+                top: 1,
+                bottom: 1,
+                left: 1,
+                right: 1,
+                background: { r: 0, g: 0, b: 0, alpha: 0 },
+            })
+            .toBuffer();
+    }
+    return imageBuffer;
 }
 
 export async function renderMultipleToPng(
@@ -152,18 +185,12 @@ export async function renderMultipleToPng(
         .composite(compositeInputs)
         .toBuffer();
 
-    if (padding > 0) {
-        compositeImage = await sharp(compositeImage)
-            .png()
-            .extend({
-                top: padding,
-                bottom: padding,
-                left: padding,
-                right: padding,
-                background,
-            })
-            .toBuffer();
-    }
+    compositeImage = await addPaddings(
+        compositeImage,
+        padding,
+        background,
+        options?.preserveAlpha ?? false,
+    );
 
     return new Uint8Array(compositeImage);
 }
@@ -187,18 +214,12 @@ export async function renderToPng(
     const background = options?.backgroundColor ?? "white";
 
     let image = await renderSvgToPng(svg, scale, background);
-    if (padding > 0) {
-        image = await sharp(image)
-            .extend({
-                top: padding,
-                bottom: padding,
-                left: padding,
-                right: padding,
-                background,
-            })
-            .png()
-            .toBuffer();
-    }
+    image = await addPaddings(
+        image,
+        padding,
+        background,
+        options?.preserveAlpha ?? false,
+    );
 
     return new Uint8Array(image);
 }


### PR DESCRIPTION
周りに 1px ずつ透明な領域を設ける